### PR TITLE
fixing CSS (Cross Site Scripting) vuln

### DIFF
--- a/_layouts/search.html
+++ b/_layouts/search.html
@@ -40,7 +40,7 @@
 <script>
   var term = getQueryVariable("q")
 
-  $("#injectQuery").html(term)
+  $("#injectQuery").text(term)
   returnSearchData(performSearch)
 
   // TODO: Optimise this


### PR DESCRIPTION
using .text() instead of .html prevents a possible CSS vuln that could be used to exploit others using your page. Try this url to test it:
`https://learninglms.gq/search/?q=script%3Cscript%3Ealert(%27CSS%20vuln%27);%3C/script%3E`